### PR TITLE
Count Up ゲームに点数予測を追加

### DIFF
--- a/src/components/molecules/SiPointPrediction.vue
+++ b/src/components/molecules/SiPointPrediction.vue
@@ -1,0 +1,55 @@
+<template>
+  <si-card v-bind="vbCard">
+    <template #header>
+      <span class="title">Point Prediction</span>
+    </template>
+    <span class="point">{{ predictionPoint }}</span>
+  </si-card>
+</template>
+<script lang="ts">
+import { Component, Vue, Prop } from 'nuxt-property-decorator';
+import { SiCard } from '~/components/atomsCatalog';
+
+@Component({ components: { SiCard } })
+export default class SiPointPrediction extends Vue {
+  @Prop({ default: 0 })
+  public readonly point!: number;
+  @Prop({ default: 0 })
+  public readonly roundIndex!: number;
+  @Prop({ default: 0 })
+  public readonly throwIndex!: number;
+  @Prop({ default: 8 })
+  public readonly totalRound!: number;
+  @Prop({ default: 'skyblue' })
+  public readonly color!: string;
+
+  public get predictionPoint() {
+    if (this.roundIndex === 0 && this.throwIndex === 0) return 0;
+    return Math.floor(
+      (this.point / (this.roundIndex * 3 + this.throwIndex)) *
+        this.totalRound *
+        3
+    );
+  }
+
+  private get vbCard(): Partial<SiCard> {
+    return {
+      bodyStyle: {
+        width: '160px',
+        textAlign: 'center',
+        backgroundColor: this.color,
+      },
+      shadow: 'never',
+    };
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.title {
+  font-size: 1.5em;
+}
+.point {
+  font-size: 3em;
+}
+</style>

--- a/src/components/moleculesCatalog.ts
+++ b/src/components/moleculesCatalog.ts
@@ -10,6 +10,7 @@ import SiRadioGroup from './molecules/SiRadioGroup.vue';
 import SiRound from './molecules/SiRound.vue';
 import SiRoundThrow from './molecules/SiRoundThrow.vue';
 import SiSubMenu from './molecules/SiSubMenu.vue';
+import SiPointPrediction from './molecules/SiPointPrediction.vue';
 
 export {
   SiCricketNumbers,
@@ -20,6 +21,7 @@ export {
   SiPlayerCard,
   SiPlayerCardWithPoint,
   SiPlayerCricketMarks,
+  SiPointPrediction,
   SiRadioGroup,
   SiRound,
   SiRoundThrow,

--- a/src/components/pages/CountUp/PlayingPage.vue
+++ b/src/components/pages/CountUp/PlayingPage.vue
@@ -6,6 +6,7 @@
       </el-col>
       <el-col :span="16">
         <div class="center-content">
+          <si-point-prediction v-bind="vbPointPrediction" />
           <div class="content">{{ totalPoint }}</div>
           <player-card-list-with-point v-bind="vbPlayerCardListWithPoint" />
         </div>
@@ -21,7 +22,7 @@
 <script lang="ts">
 import { Component, mixins, Ref } from 'nuxt-property-decorator';
 
-import { SiRoundThrow } from '~/components/moleculesCatalog';
+import { SiPointPrediction, SiRoundThrow } from '~/components/moleculesCatalog';
 import BasePage from '~/components/pages/ComponentBase/PlayingBaseComponent';
 import PlayingLeftContent from '~/components/organism/PlayingLeftContent.vue';
 import PlayerCardListWithPoint from '~/components/organism/PlayerCardListWithPoint.vue';
@@ -37,6 +38,7 @@ import {
 
 @Component({
   components: {
+    SiPointPrediction,
     SiRoundThrow,
     PlayerCardListWithPoint,
     PlayerChangeDialog,
@@ -99,6 +101,15 @@ export default class PlayingPage extends mixins<BasePage>(BasePage) {
     return {
       points: this.points.map(x => x.reduce((prev, current) => prev + current)),
       currentPlayer: this.currentPlayer,
+    };
+  }
+
+  private get vbPointPrediction(): Partial<SiPointPrediction> {
+    return {
+      point: this.totalPoint,
+      roundIndex: this.currentRoundIndex,
+      throwIndex: this.currentThrowIndex,
+      totalRound: this.totalRound,
     };
   }
 

--- a/src/components/pages/CricketCountUp/PlayingPage.vue
+++ b/src/components/pages/CricketCountUp/PlayingPage.vue
@@ -7,7 +7,7 @@
       <el-col :span="16">
         <div class="center-content">
           <div class="content">
-            <div style="font-size: 0.25em;">
+            <div style="font-size: 0.25em">
               Shoot At {{ shootCricketNumber }}
             </div>
             <cricket-count-up-darts-board v-bind="vbCricketCountUpDartsBoard" />


### PR DESCRIPTION
# Count Up ゲームに点数予測を追加

## 仕様

```
予測点数 = (現在の得点 / 投げた回数) * ラウンド数 * 3
```

## 課題

一旦予測点数の表示だけを実装しました。見た目にはこだわっていません。
期待される UI があれば教えて下さい。